### PR TITLE
Add configurable research base

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,23 @@ source env/bin/activate
 pip install -r requirements.txt
 ```
 
-Run the server:
+Run the cupcake demo server:
 
 ```shell
 python sample_mcp.py
+```
+
+For a more generic research server, run:
+
+```shell
+python general_mcp.py
 ```
 
 The server will start on `http://127.0.0.1:8000` using SSE transport.
 
 ## Files
 
-- `sample_mcp.py`: Main server code
-- `records.json`: Cupcake order data (must be present in the same directory)
+- `sample_mcp.py`: Cupcake-specific example server
+- `general_mcp.py`: Generic research server built on `research_base`
+- `research_base.py`: Provides configuration and pluggable search strategies
+- `records.json`: Example data file (must be present in the same directory)

--- a/general_mcp.py
+++ b/general_mcp.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastmcp.server import FastMCP
+
+from research_base import ResearchBase, ResearchConfig
+
+
+def create_server(config: ResearchConfig | None = None) -> FastMCP:
+    base = ResearchBase(config)
+    mcp = FastMCP(name=base.config.name, instructions=base.config.instructions)
+
+    @mcp.tool()
+    async def search(query: str, method: str | None = None):
+        """Search records using the given method."""
+        results = base.search(query, method=method)
+        return {"ids": [r["id"] for r in results]}
+
+    @mcp.tool()
+    async def fetch(id: str):
+        """Fetch a record by ID."""
+        return base.fetch(id)
+
+    return mcp
+
+
+if __name__ == "__main__":
+    create_server().run(transport="sse", host="127.0.0.1", port=8000)

--- a/research_base.py
+++ b/research_base.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Any
+
+from pydantic_settings import BaseSettings
+
+
+class ResearchConfig(BaseSettings):
+    """Configuration for research servers."""
+
+    name: str = "Research MCP"
+    instructions: str = "Search records"
+    records_path: str = "records.json"
+    default_search: str = "simple"
+    extra_vars: Dict[str, Any] = {}
+
+
+class ResearchBase:
+    """Simple research base with pluggable search strategies."""
+
+    def __init__(self, config: ResearchConfig | None = None):
+        self.config = config or ResearchConfig()
+        self.records = self._load_records(self.config.records_path)
+        self.lookup = {r["id"]: r for r in self.records}
+        self.search_methods: Dict[str, Callable[[Iterable[dict], str], List[dict]]] = {}
+        # register built-in strategy
+        self.register_search("simple", self._simple_search)
+
+    @staticmethod
+    def _load_records(path: str) -> List[dict]:
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Records file not found: {path}")
+        return json.loads(p.read_text())
+
+    def register_search(
+        self, name: str, func: Callable[[Iterable[dict], str], List[dict]]
+    ) -> None:
+        self.search_methods[name] = func
+
+    # default search implementation
+    def _simple_search(self, records: Iterable[dict], query: str) -> List[dict]:
+        toks = query.lower().split()
+        hits: List[dict] = []
+        for r in records:
+            hay = " ".join(
+                [r.get("title", ""), r.get("text", ""), " ".join(r.get("metadata", {}).values())]
+            ).lower()
+            if any(t in hay for t in toks):
+                hits.append(r)
+        return hits
+
+    def search(self, query: str, *, method: str | None = None) -> List[dict]:
+        method = method or self.config.default_search
+        if method not in self.search_methods:
+            raise ValueError(f"unknown search method: {method}")
+        return self.search_methods[method](self.records, query)
+
+    def fetch(self, id: str) -> dict:
+        if id not in self.lookup:
+            raise ValueError("unknown id")
+        return self.lookup[id]


### PR DESCRIPTION
## Summary
- introduce `research_base.py` for loading records, config values, and pluggable search strategies
- add `general_mcp.py` server that uses `research_base` for generic research tasks
- document the new server and modules in README

## Testing
- `python -m py_compile research_base.py general_mcp.py sample_mcp.py`
- `pip install -q -r requirements.txt` *(fails: fastapi requires older pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_685b59b8592083288c8448721e8421c1