### PR TITLE
Add pytest and reflex to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Deprecated direct dependency pins.
 # Please use the compiled lock files instead.
 -r requirements.lock
-
+pytest
+reflex


### PR DESCRIPTION
## Summary
- add pytest and reflex to the top-level requirements.txt so they are available when the lock file is consumed

## Testing
- reflex run --env prod *(fails: current frontend code is incompatible with Reflex 0.8 and aborts during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68d997b9a0ac8328b55671325335c421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined dependency management by removing reliance on a lockfile, simplifying setup and reducing potential installation issues across environments.
* **Tests**
  * Ensured testing tools are installed by default, improving reliability and consistency of test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->