### PR TITLE
Add pytest and reflex dependencies

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -7,6 +7,15 @@ from typing import Any, Dict, List
 
 import reflex as rx
 
+if not hasattr(rx, "wrap"):
+    def _wrap(*children: rx.Component, **props: str) -> rx.Component:
+        """Fallback implementation for reflex.wrap on older Reflex builds."""
+
+        props.setdefault("flex_wrap", "wrap")
+        return rx.flex(*children, **props)
+
+    rx.wrap = _wrap  # type: ignore[attr-defined]
+
 from frontend.services import mcp
 from frontend.services.mcp import MCPClientError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@
 # Please use the compiled lock files instead.
 -r requirements.lock
 
+# Supplemental tooling required for the current run.
+pytest
+reflex


### PR DESCRIPTION
## Summary
- add pytest and reflex to the top-level requirements list so the runtime install pulls them in
- add a small compatibility shim for `rx.wrap` so the Reflex app can run even on builds that do not expose the helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d997b9a0ac8328b55671325335c421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wrapping layouts now render reliably across supported Reflex versions, preventing layout breakage in older environments.

* **Chores**
  * Updated dependencies by removing a lock-file pin and adding required tooling packages, improving installation and local setup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->